### PR TITLE
Remplacer wordpress.org par fr.wordpress.org lorsqu'une ressource francophone est disponible

### DIFF
--- a/best-practices-WordPress/fiches/00. Préface.md
+++ b/best-practices-WordPress/fiches/00. Préface.md
@@ -7,23 +7,23 @@ path: /fiches/00-preface
 
 # 00. Préface
 
-==/_Parler de WordPress / différence entre un WordPress hébergé et _[_Wordpress.com_](http://wordpress.com/)_ Parler de l'écoconception_/==
+==/_Parler de WordPress / différence entre un WordPress hébergé et _[_Wordpress.com_](https://wordpress.com/)_ Parler de l'écoconception_/==
 
 Wordpress, est un [[cms|CMS]], autrement dit : tous types de profils : non développeur, développeur débutant ou développeur avancé peut créer son site internet en un rien de temps : Wordpress promet même une installation en 5 minutes ! Ainsi tout le monde peut aujourd'hui créer son site internet.
 
 Les parts de marché de Wordpress sont énormes : elles représentent aujourd'hui 60.8 % du marché des CMS. Aujourd'hui 40 % des sites internet qui existent utilisent Wordpress !
 
-Il faut bien différencier [wordpress.com](http://wordpress.com/) et [wordpress.org](http://wordpress.org/) car même si le système paraît le même, il n'en est rien côté back-office.
+Il faut bien différencier [wordpress.com](https://wordpress.com/) et [wordpress.org](https://fr.wordpress.org/) car même si le système paraît le même, il n'en est rien côté back-office.
 
 En effet, [wordpress.](http://wordpress.com/)org réuni tous les fichiers nécessaires à la création d'un site internet : template de base, fichiers de paramétrage et de mise en forme et un back office afin de permettre à l'utilisateur de créer son site à l'image qu'il le souhaite en utilisant les fonctions basiques tel que l'ajout d'un logo, changer les couleurs, la présentation....
 
-[Wordpress.org](http://wordpress.org/) permet de télécharger dans la langue souhaité cet ensemble de fichiers qui compose un site internet.
+[Wordpress.org](https://fr.wordpress.org/) permet de télécharger dans la langue souhaité cet ensemble de fichiers qui compose un site internet.
 
-Une fois téléchargé sur le site officiel : <https://wordpress.org/> il faut à présent ajouter ce paquet de fichiers sur un hébergement ( donc à part ) puis le relier à un nom de domaine ( acheté à part également ).
+Une fois téléchargé sur le site officiel : <https://fr.wordpress.org/> il faut à présent ajouter ce paquet de fichiers sur un hébergement ( donc à part ) puis le relier à un nom de domaine ( acheté à part également ).
 
 Il permet une grande liberté d'action aussi bien pour le novice que le développeur avancé qui va pouvoir changer de template ( modèle d'un site : comment il s'affiche ) , ajouter des plug-ins ( extensions ) qui va customiser le site ( exemple : formulaire de contact, boutique en ligne etc....) et encore bien d'autres choses... par le biais du back office.
 
-Quand à [Wordpress.com](http://wordpress.com/), le système est le même sauf que le nom de domaine sera proposé en [monsite.wordpress.com](http://monsite.wordpress.com/) , que l'hébergeur est intégré ( c'est la plateforme elle-même qui auto-héberge votre site moyennant un abonnement mensuel ou annuel plus ou moins élévé ).
+Quand à [Wordpress.com](https://wordpress.com/), le système est le même sauf que le nom de domaine sera proposé en [monsite.wordpress.com](https://monsite.wordpress.com/) , que l'hébergeur est intégré ( c'est la plateforme elle-même qui auto-héberge votre site moyennant un abonnement mensuel ou annuel plus ou moins élévé ).
 
 Le niveau de customisation possible sera selon votre niveau d'abonnement : en effet, la customisation est très limitée et soumise à l'achat d'un niveau supérieur d'abonnement .
 
@@ -33,6 +33,6 @@ Le back-office est donc très limité également et ne permet pas une totale lib
 
 Même si Wordpress est pratique car il permet un gain de temps pour créer son site internet il est cependant pointé du doigt comme étant un système très polluant.
 
-En effet, le coût pour l'environnement est énorme : que l'on utilise [wordpress.com](http://wordpress.com/) ou [wordpress.org](http://wordpress.org/), le principe est le même : des fichiers sont stockés dans un data center, des requêtes sont faites à des serveurs : afin d'"appeler" telle ou telle page au bon moment, des images sont stockées, des vidéos, usant ainsi les datas centers, les serveurs, les terminaux utilisateurs ( qui appellent ces données par la consultation d'un site internet ou d'une application ).
+En effet, le coût pour l'environnement est énorme : que l'on utilise [wordpress.com](https://wordpress.com/) ou [wordpress.org](https://fr.wordpress.org/), le principe est le même : des fichiers sont stockés dans un data center, des requêtes sont faites à des serveurs : afin d'"appeler" telle ou telle page au bon moment, des images sont stockées, des vidéos, usant ainsi les datas centers, les serveurs, les terminaux utilisateurs ( qui appellent ces données par la consultation d'un site internet ou d'une application ).
 
-Les fichiers de base téléchargés ( [wordpress.com](http://wordpress.com/) ) ou déjà en place ( [wordpress.org](http://wordpress.org/)) sont plutôt gros et gras en terme de code : effectivement vous n'allez peut être pas utiliser toutes les fonctionnalités installés, ni toutes les options ( c'est bien le principe d'une option : cela permet un choix, mais si ce choix existe c'est que toutes les possibilités sont déjà écrites en code et mises en place afin que d'un clic votre choix soit validés par le système et apparaissent ) : c'est donc du code inutiles ( mais des données bien existantes pourtant )et donc également des capacités de stockage utilisées pour rien.
+Les fichiers de base téléchargés ( [wordpress.com](https://wordpress.com/) ) ou déjà en place ( [wordpress.org](https://fr.wordpress.org/)) sont plutôt gros et gras en terme de code : effectivement vous n'allez peut être pas utiliser toutes les fonctionnalités installés, ni toutes les options ( c'est bien le principe d'une option : cela permet un choix, mais si ce choix existe c'est que toutes les possibilités sont déjà écrites en code et mises en place afin que d'un clic votre choix soit validés par le système et apparaissent ) : c'est donc du code inutiles ( mais des données bien existantes pourtant )et donc également des capacités de stockage utilisées pour rien.

--- a/best-practices-WordPress/fiches/12. Utiliser un système Cache.md
+++ b/best-practices-WordPress/fiches/12. Utiliser un système Cache.md
@@ -31,7 +31,7 @@ Le paramètre à insérer dans wp-config.php est :
 
 L'ajout du cache via une extension apporte quant à elle de nombreuses possibilités.
 
-Il en existe différentes, chacune ayant des fonctions particulières (<https://wordpress.org/plugins/tags/cache/>). Selon l'hébergeur, la version de Wordpress installée, elles n'auront pas les mêmes effets. Ainsi il n'est pas possible de vous proposer un plugin en particuliers, et il est recommandé d'en tester différentes afin d'optimiser le résultat.
+Il en existe différentes, chacune ayant des fonctions particulières (<https://fr.wordpress.org/plugins/tags/cache/>). Selon l'hébergeur, la version de Wordpress installée, elles n'auront pas les mêmes effets. Ainsi il n'est pas possible de vous proposer un plugin en particuliers, et il est recommandé d'en tester différentes afin d'optimiser le résultat.
 
 **Résultat :**
 

--- a/best-practices-WordPress/fiches/22. La taille des images.md
+++ b/best-practices-WordPress/fiches/22. La taille des images.md
@@ -47,7 +47,7 @@ Sachant que votre site va finalement n'utiliser que des versions de tailles réd
 
 ### Solution no-code 🌱
 
-Voici un plugin pour créer des vignettes (`post-thumbnails`) et regénéner les images pour qu'elles soient disponnible dans WordPress : https://wordpress.org/plugins/regenerate-thumbnails-advanced/
+Voici un plugin pour créer des vignettes (`post-thumbnails`) et regénéner les images pour qu'elles soient disponnible dans WordPress : https://fr.wordpress.org/plugins/regenerate-thumbnails-advanced/
 
 ### Solution code 🌱🌱🌱
 
@@ -78,7 +78,7 @@ function mysite_custom_image_sizes($sizes)
 }
 ```
 
-Utilisez ce plugin pour regénéner les vignettes suite à leur ajout dans la configuration : https://wordpress.org/plugins/regenerate-thumbnails/
+Utilisez ce plugin pour regénéner les vignettes suite à leur ajout dans la configuration : https://fr.wordpress.org/plugins/regenerate-thumbnails/
 
 ## Principe de validation
 

--- a/lexique/Lexique.md
+++ b/lexique/Lexique.md
@@ -24,4 +24,4 @@ toIndex: false
 - Template : Ensemble de fichier (php) qui mets en relations les éléments pour afficher le thème
 - Thème : Ensemble qui défini le graphisme du site
 - WordPress
-- [WordPress.org](http://wordpress.org/) / [WorPress.com](http://worpress.com/)
+- [WordPress.org](https://fr.wordpress.org/) / [WorPress.com](https://worpress.com/)


### PR DESCRIPTION
C'est le cas pour tous les liens vers le site général WordPress.org ainsi que pour toutes les pages de toutes les extensions hébergées sur le répertoire d'extensions WordPress.org :)